### PR TITLE
45 display name in tooltip

### DIFF
--- a/frontend/src/components/graph/Graph.tsx
+++ b/frontend/src/components/graph/Graph.tsx
@@ -195,7 +195,7 @@ function GraphVis() {
             //   });
             div.transition()
                 .duration(200)
-                .style("opacity", .9);
+                .style("opacity", 1);
             div.html(d.name.split(" ").join("<br/>"))
                 .style("left", (event.pageX) + "px")
                 .style("top", (event.pageY) + "px");

--- a/frontend/src/css/style.css
+++ b/frontend/src/css/style.css
@@ -27,10 +27,10 @@ svg {
 div.tooltip {
 	position: absolute;
 	text-align: center;
-	padding: 3px;
+	padding: 6px;
 	font: 12px sans-serif;
-	background: lightsteelblue;
-	border: 0px;
+	background: rgb(230, 212, 170);
+	border: 1px solid black;
 	border-radius: 8px;
 	pointer-events: none;
 	font-weight: bold


### PR DESCRIPTION
Consultant name displayed in tooltip.

Removed foreignObject HTML for consultants - absolute width and height resulted in html extending over other nodes.