### PR TITLE
Expand svg to screen width

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,7 +19,7 @@ function App(): JSX.Element {
         <Predicate/>
         <Filter/>
       </Stack>
-      <Box sx={{display:"flex", border:"1px solid #1a6714"}}>
+      <Box sx={{display:"flex", flexGrow: 1, border:"1px solid #1a6714"}}>
         <GraphVis/>
       </Box>
     </Stack>

--- a/frontend/src/components/graph/Graph.tsx
+++ b/frontend/src/components/graph/Graph.tsx
@@ -266,6 +266,8 @@ function GraphVis() {
     return(
         <svg
             ref={ref}
+            height="100%"
+            width="100%"
         />
     )
 }


### PR DESCRIPTION
SVG expands to screen width on Chrome, Firefox and Edge