### PR TITLE
72 fix filter issues

### DIFF
--- a/frontend/src/components/filter/filter.tsx
+++ b/frontend/src/components/filter/filter.tsx
@@ -55,7 +55,7 @@ export default function Filter() {
           <Stack direction="row" spacing={3}>
         {allGroupsChunked.map(function(chunk: string[]) {
           return(
-            <Stack>
+            <Stack sx={{pt:0.5}}>
             {chunk.map(function(group: string) {
             return(
               <FormControl component="fieldset" variant="outlined">


### PR DESCRIPTION
Fixed issue with unchecked filter changing padding.

To filter all data, backend will need to be changed from apoc to match all nodes and relationships - not simple and should be covered in future issue.