### PR TITLE
Only consultant nodes displayed if all hidden

### DIFF
--- a/app/routers/consultants.py
+++ b/app/routers/consultants.py
@@ -6,13 +6,18 @@ from pipeline.src.neo4j_connect import Neo4jConnection
 
 consultants_router = APIRouter()
 
-# MATCH pa=(c:Consultant)-[:KNOWS]-(s) where s.Name = 'REACT' 
-# unwind nodes(pa) as na
-# MATCH pb=(na)-[:KNOWS]->(t) where t.Name = "REDUX"
-# unwind nodes(pb) as nb unwind relationships(pb) as rb
-# with collect( distinct {id: ID(nb), name: nb.Name, group: labels(nb)[0]}) as nl, 
-# collect( distinct {id: ID(rb), source: ID(startnode(rb)), target: ID(endnode(rb))}) as rl
-# RETURN {nodes: nl, links: rl}
+"""
+Get consultants who know BIOVIA ONELab along with their known skills but don't return skills in ScienceApps or Process categories:
+
+MATCH pa=(c:Consultant)-[:KNOWS]->(sa) where sa.Name = 'BIOVIA ONELab'
+unwind nodes(pa) as na  
+MATCH pb=(na)-[:KNOWS]->() 
+WHERE NONE(n IN nodes(pb) WHERE n:ScienceApps OR n:Process) 
+unwind nodes(pb) as nb unwind relationships(pb) as rb 
+with collect( distinct {id: ID(nb), name: nb.Name, group: labels(nb)[0]}) as nzz, 
+collect( distinct {id: ID(rb), source: ID(startnode(rb)), target: ID(endnode(rb))}) as rzz 
+RETURN {nodes: nzz, links: rzz}
+"""
 
 def char(num: int):
     return chr(num + 97)
@@ -23,6 +28,20 @@ async def filter_consultants_by_skills(
     hidden_groups: List[str] = Query(default=[])
     ):
     conn = Neo4jConnection(uri="neo4j://neo4j-db:7687", user="neo4j", password="test")
+
+    all_hidden = False
+    if hidden_groups:
+        all_labels_result = conn.query("MATCH (n) RETURN distinct labels(n)")
+        all_groups = [label.values("labels(n)")[0][0] for label in all_labels_result]
+        if "Consultant" in all_groups:
+            all_groups.remove("Consultant")
+
+        all_groups.sort()
+        hidden_groups.sort()
+        if all_groups == hidden_groups:
+            all_hidden = True
+
+    print(all_hidden)
 
     query = "MATCH pa=(c:Consultant)-[:KNOWS]->(sa) "
     for i, skill in enumerate(skills):
@@ -37,8 +56,12 @@ async def filter_consultants_by_skills(
     final_char = char(len(skills))
 
     query += f"unwind nodes(p{penult_char}) as n{penult_char} "
-    query += f" MATCH p{final_char}=(n{penult_char})-[:KNOWS]->()"
 
+    if not all_hidden:
+        query += f" MATCH p{final_char}=(n{penult_char})-[:KNOWS]->()"
+    else:
+        query += f" MATCH p{final_char}=(n{penult_char})"
+    
     if hidden_groups:
         query += f" WHERE NONE(n IN nodes(p{final_char}) WHERE"
         for i, group in enumerate(hidden_groups):
@@ -48,7 +71,13 @@ async def filter_consultants_by_skills(
             else:
                 query += ")"
 
-    query += neo4j_to_d3_cypher(final_char)
+    if all_hidden:
+        query += f" unwind nodes(p{final_char}) as nb"
+        query += " with collect( distinct {id: ID(n" + final_char + f"), name: nb.Name, group: labels(n{final_char})[0]" + "}) as nzz"
+        query += " return {nodes: nzz, links: []}"
+
+    else:
+        query += neo4j_to_d3_cypher(final_char)
 
     print(query)
 

--- a/frontend/src/components/filter/hideAllButton.tsx
+++ b/frontend/src/components/filter/hideAllButton.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Button } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
-import { selectHiddenGroups, filterGraphDataRequest, isGraphDisplayable, setHiddenGroups, selectCurrentNodes } from "../graph/graphSlice";
+import { selectHiddenGroups, filterGraphDataRequest, isGraphDisplayable, setHiddenGroups, selectCurrentNodes, selectAllNodes } from "../graph/graphSlice";
 import { selectRuleList } from "../search/searchSlice";
 import { getUniqueGroups } from "../../hooks/useD3";
 
@@ -11,16 +11,16 @@ export default function HideAllButton() {
 
   const dispatch = useAppDispatch()
 
-  const currentNodeData = useAppSelector(selectCurrentNodes)
-  const currentGroups = getUniqueGroups(currentNodeData)
-  const hiddenGroups = useAppSelector(selectHiddenGroups)
+  const allNodeData = useAppSelector(selectAllNodes)
+  const allGroups = getUniqueGroups(allNodeData)
 
   let skills = useAppSelector(selectRuleList)
   skills = skills.map(function(skill: any) {return skill.name})
 
   const handleClick = () => {
-    currentGroups.map(function(group: string) {dispatch(setHiddenGroups(group))})
-    skills.length && dispatch(filterGraphDataRequest({skills: skills, hiddenGroups: currentGroups}))
+    const allSkillGroups = allGroups.filter(function(group: string) {return group !== "Consultant"})
+    allSkillGroups.map(function(group: string) {dispatch(setHiddenGroups(group))})
+    skills.length && dispatch(filterGraphDataRequest({skills: skills, hiddenGroups: allSkillGroups}))
     }
 
   return(


### PR DESCRIPTION
Cypher query updated so that if all groups (except Consultant) hidden in request, consultant nodes are still returned with no links.

Hide all button performs this correctly.

Note: hide all button sends through all groups rather than current groups - i.e. if a query results in one group not being displayed - it will also be sent to backend and query will be triggered to only return consultant nodes. 