### PR TITLE
Allow multiple parentheses in search list

### DIFF
--- a/frontend/src/components/search/bitwiseOperators.tsx
+++ b/frontend/src/components/search/bitwiseOperators.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Stack, ToggleButtonGroup, ToggleButton } from "@mui/material"
 import { useAppDispatch, useAppSelector } from "../../app/hooks"
-import { selectCurrentSearchOperator, selectCurrentSearchParenthesis, selectRuleList, setCurrentBitwiseOperatorSearch } from "./searchSlice"
+import { clearCurrentParenthesis, selectCurrentSearchOperator, selectCurrentSearchParenthesis, selectRuleList, setCurrentBitwiseOperatorSearch } from "./searchSlice"
 import { useEffect } from "react"
 
 export default function BitwiseOperators() {
@@ -12,38 +12,36 @@ export default function BitwiseOperators() {
   let parenthesis = useAppSelector(selectCurrentSearchParenthesis)
   const searchList = useAppSelector(selectRuleList)
 
-  let disableParentheses = false
   const numOpenParentheses = searchList.filter(function(rule: any) {return rule.parenthesis === "["}).length
   const numClosedParentheses = searchList.filter(function(rule: any) {return rule.parenthesis === "]"}).length
   let parenthesesOpen = false
-  if (numOpenParentheses > 0) {
-    if (numClosedParentheses === 0) {
-      parenthesesOpen = true
-      if (parenthesis !== "]") {
-        parenthesis = ""
-      } 
-    }
-    if (numClosedParentheses > 0) {
-      // only allow one set of parentheses for now
-      parenthesis = ""
-      disableParentheses = true
-    }
+  if (numOpenParentheses === numClosedParentheses) {
+    parenthesesOpen = false
+  }
+  else {
+    parenthesesOpen = true
   }
 
   useEffect(() => {
+    dispatch(clearCurrentParenthesis())
+
     if (searchList.length > 0 && operator === "") {
-      dispatch(setCurrentBitwiseOperatorSearch({operator: "AND", parenthesis: parenthesis}))
+      dispatch(setCurrentBitwiseOperatorSearch({operator: "AND", parenthesis: ""}))
     }
-    else if (searchList.length === 0) {
+    if (searchList.length === 0) {
       dispatch(setCurrentBitwiseOperatorSearch({operator: "", parenthesis: ""}))
     }
   }, [searchList])
+
+  console.log(searchList)
 
   const handleOperatorChange = (
     _event: React.MouseEvent<HTMLElement>,
     newOperator: string | null,
   )  => {
-    dispatch(setCurrentBitwiseOperatorSearch({operator: newOperator, parenthesis: parenthesis}));
+    if (newOperator !== null) {
+      dispatch(setCurrentBitwiseOperatorSearch({operator: newOperator, parenthesis: parenthesis}));
+    }
   }
 
   const handleParenthesisChange = (
@@ -72,10 +70,10 @@ export default function BitwiseOperators() {
         onChange={handleParenthesisChange}
         exclusive
       >
-        <ToggleButton value="[" disabled={parenthesesOpen || disableParentheses}>
+        <ToggleButton value="[" disabled={parenthesesOpen}>
           [
         </ToggleButton>
-        <ToggleButton value="]" disabled={!parenthesesOpen || disableParentheses}>
+        <ToggleButton value="]" disabled={!parenthesesOpen}>
           ]
         </ToggleButton>
       </ToggleButtonGroup>

--- a/frontend/src/components/search/ruleOperator.tsx
+++ b/frontend/src/components/search/ruleOperator.tsx
@@ -1,0 +1,24 @@
+import React from "react"
+import { Stack, Typography, Paper } from "@mui/material";
+import { useAppSelector } from "../../app/hooks";
+import { selectRuleList } from "./searchSlice";
+import { selectAllNodes } from "../graph/graphSlice";
+import { getUniqueGroups } from "../../hooks/useD3";
+import * as d3 from "d3"
+import { groupDisplayNameLinks } from "../../constants/data";
+
+interface IRuleOperator {
+  operator: string;
+}
+
+export default function RuleOperator({operator}: IRuleOperator) {
+
+  const nodeData = useAppSelector(selectAllNodes)
+  const groups = getUniqueGroups(nodeData)
+
+  return(
+    <Typography variant="subtitle2" sx={{px: 1, fontWeight:"bold"}}>
+      {operator}
+    </Typography>
+  )
+}

--- a/frontend/src/components/search/ruleSkill.tsx
+++ b/frontend/src/components/search/ruleSkill.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { Stack, Typography, Paper } from "@mui/material";
+import { useAppSelector } from "../../app/hooks";
+import { selectRuleList } from "./searchSlice";
+import { selectAllNodes } from "../graph/graphSlice";
+import { getUniqueGroups } from "../../hooks/useD3";
+import * as d3 from "d3"
+import { groupDisplayNameLinks } from "../../constants/data";
+
+interface IRuleSkill {
+  group: string;
+  name: string;
+}
+
+export default function RuleSkill({group, name}: IRuleSkill) {
+
+  const nodeData = useAppSelector(selectAllNodes)
+  const groups = getUniqueGroups(nodeData)
+
+  return(
+    <Paper>
+      <Stack direction="row" alignItems="center">
+        <Typography sx={{backgroundColor: d3.schemePaired[groups.indexOf(group)] + "90", px:1.5, py:1, fontSize: 14}}>{groupDisplayNameLinks[group]}</Typography>
+        <Typography sx={{pl:2, fontSize: 14}}>{name}</Typography>
+      </Stack>
+    </Paper>
+  )
+}

--- a/frontend/src/components/search/searchList.tsx
+++ b/frontend/src/components/search/searchList.tsx
@@ -6,6 +6,10 @@ import { selectAllNodes } from "../graph/graphSlice";
 import { getUniqueGroups } from "../../hooks/useD3";
 import * as d3 from "d3"
 import { groupDisplayNameLinks } from "../../constants/data";
+import RuleSkill from "./ruleSkill";
+import RuleOperator from "./ruleOperator";
+
+
 
 export default function SearchList() {
 
@@ -15,8 +19,15 @@ export default function SearchList() {
 
   let open = false
 
-  const startBracketIdx = searchList.map(function(rule: any, i:number) {return(rule.parenthesis)}).indexOf("[")
-  const endBracketIdx = searchList.map(function(rule: any, i:number) {return(rule.parenthesis)}).indexOf("]")
+  const getBracketIndexes = (char: string) => {
+    return searchList
+      .map((item: any, index: number) => ({...item, index}))
+      .filter((item: any) => item.parenthesis == char)
+      .map((item: any) => item.index)
+  }
+
+  const startBracketIdxs = getBracketIndexes("[")
+  const endBracketIdxs = getBracketIndexes("]")
 
   return(
     <Stack spacing={1}>
@@ -31,58 +42,50 @@ export default function SearchList() {
       }
 
       // if bracket is closed return node normally
-      if (!open && j !== endBracketIdx) {
+      if (!open && !endBracketIdxs.includes(j)) {
         return(
           <Stack spacing={1}>
-            {(rule.operator !== "" && (j === endBracketIdx + 1 || j !==0)) &&
-              <Typography variant="subtitle2" sx={{px: 1, fontWeight:"bold"}}>
-                {rule.operator}
-              </Typography>
+            {(rule.operator !== "" && (endBracketIdxs.map((idx: number) => idx + 1).includes(j) || j !==0)) &&
+              <RuleOperator operator={rule.operator}/>
             }
-            <Paper>
-              <Stack direction="row" alignItems="center">
-                <Typography sx={{backgroundColor: d3.schemePaired[groups.indexOf(rule.group)] + "90", px:1.5, py:1, fontSize: 14}}>{groupDisplayNameLinks[rule.group]}</Typography>
-                <Typography sx={{pl:2, fontSize: 14}}>{rule.name}</Typography>
-              </Stack>
-            </Paper>
-            {(startBracketIdx !== -1 && j === startBracketIdx - 1) &&
-            <Typography variant="subtitle2" sx={{px: 1, fontWeight:"bold"}}>
-              {searchList[startBracketIdx].operator}
-            </Typography>
-            }
+            <RuleSkill group={rule.group} name={rule.name} />
+            {/* {(startBracketIdx !== -1 && j === startBracketIdx - 1) &&
+              <RuleOperator operator={searchList[startBracketIdx].operator}/>
+            } */}
           </Stack>
           )
       }
 
       // if bracket is open then it should be wrapped in yellow paper - nothing should be returned until bracket closed
-      else if (j === endBracketIdx || j === searchList.length - 1) {
-        const endIdx = endBracketIdx === -1 ? searchList.length - 1 : endBracketIdx
+      else if (endBracketIdxs.includes(j) || j === searchList.length - 1) {
+        // const endIdx = endBracketIdx === -1 ? searchList.length - 1 : endBracketIdx
+        let startBracketIdx = startBracketIdxs[endBracketIdxs.indexOf(j)]
+        if (!endBracketIdxs.includes(j)) {
+          startBracketIdx = searchList.length - 1
+        }
         const nodesInParentheses = searchList.filter(function(rule: any, k: number) {
-          return (k >= startBracketIdx && k <= endIdx)
+          return (k >= startBracketIdx && k <= j)
         })
+        // console.log(nodesInParentheses)
         return(
-            <Paper sx={{p: 1, py:1.5, backgroundColor: "#e6d4aa"}}>
-              <Stack spacing={1}>
-              {nodesInParentheses.map(function(rule: any, k: number) {
-                  return (
-                    <Stack spacing={1}>
-                      {(rule.operator !== "" && k !== 0) &&
-                      <Typography variant="subtitle2" sx={{px: 1, fontWeight:"bold"}}>
-                        {rule.operator}
-                      </Typography>
-                      }
-                      <Paper>
-                        <Stack direction="row" alignItems="center">
-                          <Typography sx={{backgroundColor: d3.schemePaired[groups.indexOf(rule.group)] + "90", px:1.5, py:1, fontSize: 14}}>{groupDisplayNameLinks[rule.group]}</Typography>
-                          <Typography sx={{pl:2, fontSize: 14}}>{rule.name}</Typography>
-                        </Stack>
-                      </Paper>
-                    </Stack>
-                  )
-                }
-              )}
-              </Stack>
-            </Paper>
+          <Stack spacing={1}>
+            <RuleOperator operator={searchList[startBracketIdx].operator}/>
+              <Paper sx={{p: 1, py:1.5, backgroundColor: "#e6d4aa"}}>
+                <Stack spacing={1}>
+                {nodesInParentheses.map(function(rule: any, k: number) {
+                    return (
+                      <Stack spacing={1}>
+                        {(rule.operator !== "" && k !== 0) &&
+                        <RuleOperator operator={rule.operator}/>
+                        }
+                        <RuleSkill group={rule.group} name={rule.name} />
+                      </Stack>
+                    )
+                  }
+                )}
+                </Stack>
+              </Paper>
+            </Stack>
           )
         }
       })}

--- a/frontend/src/components/search/searchSlice.ts
+++ b/frontend/src/components/search/searchSlice.ts
@@ -46,6 +46,9 @@ const searchSlice = createSlice({
     clearRuleList: (state: any) => {
       state.ruleList = initialState.ruleList
     },
+    clearCurrentParenthesis: (state: any) => {
+      state.currentRule.parenthesis = initialState.currentRule.parenthesis
+    },
   },
 });
 
@@ -57,6 +60,7 @@ export const {
   clearCurrentNodeSearch,
   clearCurrentBitwiseOperatorSearch,
   clearRuleList,
+  clearCurrentParenthesis,
 } = searchSlice.actions;
 
 // Selectors


### PR DESCRIPTION
Rule operator and rule skill separated into individual components.

Multiple parentheses can now be added to search list. PR to follow where backend can handle this.