### PR TITLE
Re-add Zifo logo when new search

### DIFF
--- a/frontend/src/components/graph/graph.tsx
+++ b/frontend/src/components/graph/graph.tsx
@@ -40,6 +40,7 @@ function GraphVis() {
 
       // Remove all existing svg-groups on svg
       svg.selectAll("g").remove();
+      svg.selectAll("image").remove();
 
       // Create single root svg-group
       const rootGroup = svg.append("g");


### PR DESCRIPTION
Performing search, resizing window and performing search again was causing Zifo logo to be added twice.

Now when node/link data changes, Zifo logo is removed and re-added to svg