### PR TITLE
Create user when assigning skill if user doesn't exist

### DIFF
--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -12,6 +12,7 @@ class ExternalUser(BaseModel):
     id: str
     email: str
     username: str
+    display_name: str
 
 
 class InternalUser(BaseModel):

--- a/app/utils/security/providers.py
+++ b/app/utils/security/providers.py
@@ -77,6 +77,7 @@ class AzureAuthProvider:
 
         user_id = response_data.get("id")
         username = response_data.get("userPrincipalName")
+        display_name = response_data.get("displayName")
         email = response_data.get("mail")
 
         if email:
@@ -85,7 +86,9 @@ class AzureAuthProvider:
         if not user_id or not username or not email:
             raise UnauthorizedUser("User account not verified by Azure.")
 
-        external_user = ExternalUser(id=user_id, email=email, username=username)
+        external_user = ExternalUser(
+            id=user_id, email=email, username=username, display_name=display_name
+        )
 
         return external_user
 


### PR DESCRIPTION
If user doesn't exist in neo4j and tries to assign themselves a skill, they will now be added to neo4j.

Tested in production and working as expected.